### PR TITLE
Add uart_interrupt_init () back in

### DIFF
--- a/cybot-program/main.c
+++ b/cybot-program/main.c
@@ -38,6 +38,7 @@ void main() {
     lcd_puts("Initializing...");
 
     uart_init(115200);
+    uart_interrupt_init();
     adc_init();
     ping_init();
     servo_init();


### PR DESCRIPTION
This adds a call to uart_interrupt_init() back in to the main.c file. It was removed for some reason and without it the bot can't receive commands.